### PR TITLE
Change types from BCM2836 to BCM283X

### DIFF
--- a/hw/arm/bcm2836.c
+++ b/hw/arm/bcm2836.c
@@ -26,10 +26,10 @@
 
 static void bcm2836_init(Object *obj)
 {
-    BCM2836State *s = BCM2836(obj);
+    BCM283XState *s = BCM283X(obj);
     int n;
 
-    for (n = 0; n < BCM2836_NCPUS; n++) {
+    for (n = 0; n < BCM283X_NCPUS; n++) {
         object_initialize(&s->cpus[n], sizeof(s->cpus[n]),
                           current_machine->cpu_type);
         object_property_add_child(obj, "cpu[*]", OBJECT(&s->cpus[n]),
@@ -53,7 +53,7 @@ static void bcm2836_init(Object *obj)
 
 static void bcm2836_realize(DeviceState *dev, Error **errp)
 {
-    BCM2836State *s = BCM2836(dev);
+    BCM283XState *s = BCM283X(dev);
     Object *obj;
     Error *err = NULL;
     int n;
@@ -103,7 +103,7 @@ static void bcm2836_realize(DeviceState *dev, Error **errp)
     sysbus_connect_irq(SYS_BUS_DEVICE(&s->peripherals), 1,
         qdev_get_gpio_in_named(DEVICE(&s->control), "gpu-fiq", 0));
 
-    for (n = 0; n < BCM2836_NCPUS; n++) {
+    for (n = 0; n < BCM283X_NCPUS; n++) {
         /* Mirror bcm2836, which has clusterid set to 0xf
          * TODO: this should be converted to a property of ARM_CPU
          */
@@ -151,7 +151,7 @@ static void bcm2836_realize(DeviceState *dev, Error **errp)
 }
 
 static Property bcm2836_props[] = {
-    DEFINE_PROP_UINT32("enabled-cpus", BCM2836State, enabled_cpus, BCM2836_NCPUS),
+    DEFINE_PROP_UINT32("enabled-cpus", BCM283XState, enabled_cpus, BCM283X_NCPUS),
     DEFINE_PROP_END_OF_LIST()
 };
 
@@ -166,7 +166,7 @@ static void bcm2836_class_init(ObjectClass *oc, void *data)
 static const TypeInfo bcm2836_type_info = {
     .name = TYPE_BCM2836,
     .parent = TYPE_SYS_BUS_DEVICE,
-    .instance_size = sizeof(BCM2836State),
+    .instance_size = sizeof(BCM283XState),
     .instance_init = bcm2836_init,
     .class_init = bcm2836_class_init,
 };

--- a/hw/arm/raspi.c
+++ b/hw/arm/raspi.c
@@ -31,7 +31,7 @@
 static const int raspi_boardid[] = {[1] = 0xc42, [2] = 0xc43, [3] = 0xc44};
 
 typedef struct RasPiState {
-    BCM2836State soc;
+    BCM283XState soc;
     MemoryRegion ram;
 } RasPiState;
 
@@ -170,10 +170,10 @@ static void raspi2_machine_init(MachineClass *mc)
     mc->no_parallel = 1;
     mc->no_floppy = 1;
     mc->no_cdrom = 1;
-    mc->max_cpus = BCM2836_NCPUS;
-    mc->min_cpus = BCM2836_NCPUS;
+    mc->max_cpus = BCM283X_NCPUS;
+    mc->min_cpus = BCM283X_NCPUS;
     mc->default_cpu_type = ARM_CPU_TYPE_NAME("cortex-a15");
-    mc->default_cpus = BCM2836_NCPUS;
+    mc->default_cpus = BCM283X_NCPUS;
     mc->default_ram_size = 1024 * 1024 * 1024;
     mc->ignore_memory_transaction_failures = true;
 };
@@ -187,10 +187,10 @@ static void raspi3_machine_init(MachineClass *mc)
     mc->no_parallel = 1;
     mc->no_floppy = 1;
     mc->no_cdrom = 1;
-    mc->max_cpus = BCM2836_NCPUS;
-    mc->min_cpus = BCM2836_NCPUS;
+    mc->max_cpus = BCM283X_NCPUS;
+    mc->min_cpus = BCM283X_NCPUS;
     mc->default_cpu_type = ARM_CPU_TYPE_NAME("cortex-a53");
-    mc->default_cpus = BCM2836_NCPUS;
+    mc->default_cpus = BCM283X_NCPUS;
     mc->default_ram_size = 1024 * 1024 * 1024;
     mc->ignore_memory_transaction_failures = true;
 };


### PR DESCRIPTION
In the commit 926dcdf073a2f9cf8f8d4d71b35110544dae2b40 of qemu they changed the types from BCM2836 to BCM283X. This patch solves the type conflicts while compiling qemu with the new patches.